### PR TITLE
fix: resume and update handlers status patch fails

### DIFF
--- a/nuvolaris/main.py
+++ b/nuvolaris/main.py
@@ -339,13 +339,11 @@ def whisk_update(spec, status, namespace, diff, name, **kwargs):
     owner = kube.get(f"wsk/{name}")
 
     patcher.patch(diff, status, owner, name)
-    status['controller']= "Updated"
 
 @kopf.on.resume('nuvolaris.org', 'v1', 'whisks')
 def whisk_resume(spec, status, name, **kwargs):   
     operator_util.config_from_spec(spec, handler_type="on_resume")
     operator_util.whisk_post_resume(name)
-    status['controller']='Resumed'
 
 def runtimes_filter(name, type, **kwargs):
     return name == 'openwhisk-runtimes' and type == 'MODIFIED'  

--- a/nuvolaris/quota_checker.py
+++ b/nuvolaris/quota_checker.py
@@ -81,7 +81,7 @@ def check_pg_quota(pg_client:PostgresClient, pg_dbsize_list, pg_wsku, check_ferr
         quota_annotation = check_ferretdb and FERRRET_DB_QUOTA_ANNOTATION or POSTGRES_DB_QUOTA_ANNOTATION
         quota_applied = "false"
 
-        pg_db= check_ferretdb and f"spec['mongodb']['database']_ferretdb" or spec['postgres']['database']
+        pg_db= check_ferretdb and f"{spec['mongodb']['database']}_ferretdb" or spec['postgres']['database']
         pg_db_quota = check_ferretdb and int(spec['mongodb']['quota'])*1014*1024 or int(spec['postgres']['quota'])*1024*1024
 
         # Check if the quota annotations has been already applied


### PR DESCRIPTION
This PR fixes an issue with the openserverless operator when update and resume handler are invoked as the status object cannot be updated directly putting the operator in a never ending retry cycle.