### PR TITLE
chore: annotate system_action_status after a resume

### DIFF
--- a/nuvolaris/operator_util.py
+++ b/nuvolaris/operator_util.py
@@ -94,9 +94,11 @@ def whisk_post_resume(name):
     sysres = system.deploy_whisk_system_action()
 
     if sysres:
+        openwhisk.annotate(f"system_action_status=created")
         logging.info("system action redeployed after operator restart")
-    else:    
-        logging.warn("system action deploy issues after operator restart. Checl logs for further details")
+    else:
+        openwhisk.annotate(f"system_action_status=failed")    
+        logging.warn("system action deploy issues after operator restart. Checl logs for further details")        
 
 def config_from_spec(spec, handler_type = "on_create"):
     """


### PR DESCRIPTION
OpenServerless operator redeploys the system action also after a resume so there is the need to update the system_action_status again.