### PR TITLE
Removing MINIO_ user variables

### DIFF
--- a/TaskfileTest.yml
+++ b/TaskfileTest.yml
@@ -182,12 +182,12 @@ tasks:
     desc: minio test
     cmds:    
     - |
-      MINIO_ACCESS_KEY=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.minio_access_key}')
-      MINIO_SECRET_KEY=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.minio_secret_key}')
-      MINIO_HOST=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.minio_host}')
-      MINIO_PORT=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.minio_port}')
-      MINIO_BUCKET_DATA=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.minio_bucket_data}')
-      MINIO_BUCKET_WEB=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.minio_bucket_static}')
+      MINIO_ACCESS_KEY=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.s3_access_key}')
+      MINIO_SECRET_KEY=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.s3_secret_key}')
+      MINIO_HOST=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.s3_host}')
+      MINIO_PORT=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.s3_port}')
+      MINIO_BUCKET_DATA=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.s3_bucket_data}')
+      MINIO_BUCKET_WEB=$(kubectl -n nuvolaris get cm/config -o jsonpath='{.metadata.annotations.s3_bucket_static}')
       wsk -i action update minio/minio-nuv tests/minio-nuv.js \
       -p minio_access "$MINIO_ACCESS_KEY" \
       -p minio_secret "$MINIO_SECRET_KEY" \

--- a/actions/devel/minio/command/minio.py
+++ b/actions/devel/minio/command/minio.py
@@ -33,12 +33,12 @@ class Minio():
 
     def __init__(self, user_data):
         self._user_data = user_data        
-        self._minio_access_key= ut.get_env_value(user_data,"MINIO_ACCESS_KEY")        
-        self._minio_secret_key= ut.get_env_value(user_data,"MINIO_SECRET_KEY") 
-        self._minio_host= ut.get_env_value(user_data,"MINIO_HOST") 
-        self._minio_port= ut.get_env_value(user_data,"MINIO_PORT")
-        self._minio_data_bucket= ut.get_env_value(user_data,"MINIO_DATA_BUCKET")
-        self._minio_static_bucket= ut.get_env_value(user_data,"MINIO_STATIC_BUCKET")
+        self._minio_access_key= ut.get_env_value(user_data,"S3_ACCESS_KEY")        
+        self._minio_secret_key= ut.get_env_value(user_data,"S3_SECRET_KEY") 
+        self._minio_host= ut.get_env_value(user_data,"S3_HOST") 
+        self._minio_port= ut.get_env_value(user_data,"S3_PORT")
+        self._minio_data_bucket= ut.get_env_value(user_data,"S3_DATA_BUCKET")
+        self._minio_static_bucket= ut.get_env_value(user_data,"S3_STATIC_BUCKET")
         self.validate()
 
     def validate(self):

--- a/actions/devel/upload/__main__.py
+++ b/actions/devel/upload/__main__.py
@@ -111,7 +111,7 @@ def main(args):
             return build_error("invalid request, bucket and/or filename path error")
 
         user_data = Authorize(args['couchdb_host'],args['couchdb_user'],args['couchdb_password']).login(headers['x-impersonate-auth'])
-        mo_client = mutil.build_mo_client(ut.get_env_value(user_data,"MINIO_HOST"), ut.get_env_value(user_data,"MINIO_PORT"),ut.get_env_value(user_data,"MINIO_ACCESS_KEY")  , ut.get_env_value(user_data,"MINIO_SECRET_KEY"))        
+        mo_client = mutil.build_mo_client(ut.get_env_value(user_data,"S3_HOST"), ut.get_env_value(user_data,"S3_PORT"),ut.get_env_value(user_data,"S3_ACCESS_KEY")  , ut.get_env_value(user_data,"S3_SECRET_KEY"))        
 
         if method.lower() in 'put':
             print(f"processing request to upload file {upload_data['filename']}")

--- a/nuvolaris/minio_deploy.py
+++ b/nuvolaris/minio_deploy.py
@@ -94,7 +94,7 @@ def create(owner=None):
 
 def _annotate_nuv_metadata(data):
     """
-    annotate nuvolaris configmap with entries for minio connectivity MINIO_ENDPOINT, MINIO_PORT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY
+    annotate nuvolaris configmap with entries for minio connectivity S3_ENDPOINT, S3_PORT, S3_ACCESS_KEY, S3_SECRET_KEY
     this is becasue MINIO
     """ 
     try:
@@ -103,9 +103,6 @@ def _annotate_nuv_metadata(data):
             minio_host = f"{minio_service['metadata']['name']}.{minio_service['metadata']['namespace']}.svc.cluster.local"
             access_key = data["minio_nuv_user"]
             secret_key = data["minio_nuv_password"]
-            openwhisk.annotate(f"minio_host={minio_host}")
-            openwhisk.annotate(f"minio_access_key={access_key}")
-            openwhisk.annotate(f"minio_secret_key={secret_key}")
             openwhisk.annotate(f"s3_host={minio_host}")
             openwhisk.annotate(f"s3_access_key={access_key}")
             openwhisk.annotate(f"s3_secret_key={secret_key}")
@@ -114,7 +111,6 @@ def _annotate_nuv_metadata(data):
             ports = list(minio_service['spec']['ports'])
             for port in ports:
                 if(port['name']=='minio-api'):
-                    openwhisk.annotate(f"minio_port={port['port']}")
                     openwhisk.annotate(f"s3_port={port['port']}")                  
         return None
     except Exception as e:

--- a/nuvolaris/minio_deploy.py
+++ b/nuvolaris/minio_deploy.py
@@ -31,7 +31,7 @@ from nuvolaris.minio_util import MinioClient
 
 def _add_miniouser_metadata(ucfg: UserConfig, user_metadata:UserMetadata):
     """
-    adds entries for minio connectivity MINIO_ENDPOINT, MINIO_PORT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY
+    adds entries for minio connectivity S3_HOST, S3_PORT, S3_ACCESS_KEY, S3_SECRET_KEY
     this is becasue MINIO
     """ 
 
@@ -41,9 +41,6 @@ def _add_miniouser_metadata(ucfg: UserConfig, user_metadata:UserMetadata):
             minio_host = f"{minio_service['metadata']['name']}.{minio_service['metadata']['namespace']}.svc.cluster.local"
             access_key = ucfg.get('namespace')
             secret_key = ucfg.get("object-storage.password")
-            user_metadata.add_metadata("MINIO_HOST",minio_host)
-            user_metadata.add_metadata("MINIO_ACCESS_KEY",access_key)
-            user_metadata.add_metadata("MINIO_SECRET_KEY",secret_key)
             user_metadata.add_metadata("S3_PROVIDER","minio")
             user_metadata.add_metadata("S3_HOST",minio_host)
             user_metadata.add_metadata("S3_ACCESS_KEY",access_key)
@@ -55,7 +52,6 @@ def _add_miniouser_metadata(ucfg: UserConfig, user_metadata:UserMetadata):
             ports = list(minio_service['spec']['ports'])
             for port in ports:
                 if(port['name']=='minio-api'):
-                    user_metadata.add_metadata("MINIO_PORT",port['port'])
                     user_metadata.add_metadata("S3_PORT",port['port'])
 
 
@@ -144,7 +140,6 @@ def create_nuv_storage(data):
         bucket_policy_names.append("nuvolaris-data/*")
 
         if(res):
-            openwhisk.annotate(f"minio_bucket_data=nuvolaris-data")
             openwhisk.annotate(f"s3_bucket_data=nuvolaris-data")
 
         logging.info(f"*** adding nuvolaris MINIO static public bucket")
@@ -152,7 +147,6 @@ def create_nuv_storage(data):
         bucket_policy_names.append("nuvolaris-web/*")
 
         if(res):
-            openwhisk.annotate(f"minio_bucket_static=nuvolaris-web")
             openwhisk.annotate(f"s3_bucket_static=nuvolaris-web")
             content_path = find_content_path("index.html")
 
@@ -202,8 +196,8 @@ def create_ow_storage(state, ucfg: UserConfig, user_metadata: UserMetadata, owne
         state['storage_data']=res
 
         if(res):
-            user_metadata.add_metadata("MINIO_BUCKET_DATA",bucket_name)
             user_metadata.add_metadata("S3_BUCKET_DATA",bucket_name)
+            ucfg.put("S3_BUCKET_DATA",bucket_name)
 
             if ucfg.exists('object-storage.quota'):
                 assign_bucket_quota(bucket_name,ucfg.get('object-storage.quota'), minioClient)
@@ -215,7 +209,6 @@ def create_ow_storage(state, ucfg: UserConfig, user_metadata: UserMetadata, owne
         bucket_policy_names.append(f"{bucket_name}/*")
 
         if(res):
-            user_metadata.add_metadata("MINIO_BUCKET_STATIC",bucket_name)
             user_metadata.add_metadata("S3_BUCKET_STATIC",bucket_name)
             ucfg.put("S3_BUCKET_STATIC",bucket_name)
             
@@ -311,4 +304,4 @@ def patch_ingresses(status, action, owner=None):
         logging.info(f"*** hanlded request to {action} minio ingresses") 
     except Exception as e:
         logging.error('*** failed to update minio ingresses: %s' % e)    
-        operator_util.patch_operator_status(status,'minio-ingresses','error')           
+        operator_util.patch_operator_status(status,'minio-ingresses','error')        

--- a/nuvolaris/nuvolaris_metadata.py
+++ b/nuvolaris/nuvolaris_metadata.py
@@ -47,12 +47,6 @@ class NuvolarisMetadata:
         Populates the internal metadata starting from the cm/config map
         """        
         self.add_metadata("AUTH", cfg.get('openwhisk.namespaces.nuvolaris'))
-        self._store_safely_from_cm("MINIO_ACCESS_KEY", '{.metadata.annotations.minio_access_key}')
-        self._store_safely_from_cm("MINIO_BUCKET_DATA", '{.metadata.annotations.minio_bucket_data}')
-        self._store_safely_from_cm("MINIO_HOST", '{.metadata.annotations.minio_host}') 
-        self._store_safely_from_cm("MINIO_PORT", '{.metadata.annotations.minio_port}')  
-        self._store_safely_from_cm("MINIO_SECRET_KEY", '{.metadata.annotations.minio_secret_key}')    
-        self._store_safely_from_cm("MINIO_BUCKET_STATIC", '{.metadata.annotations.minio_bucket_static}')
         self._store_safely_from_cm("MONGODB_URL", '{.metadata.annotations.mongodb_url}')
         self._store_safely_from_cm("POSTGRES_DATABASE", '{.metadata.annotations.postgres_database}') 
         self._store_safely_from_cm("POSTGRES_HOST", '{.metadata.annotations.postgres_host}')

--- a/tests/kind/minio_test.ipy
+++ b/tests/kind/minio_test.ipy
@@ -43,6 +43,6 @@ actual_minio_root_user = kube.kubectl("get", f"pods/{pod_name}", jsonpath="{.spe
 configured_minio_root_user = cfg.get('minio.admin.user')
 assert(actual_minio_root_user[0] == configured_minio_root_user)
 
-cm_minio_url = kube.kubectl("get", f"cm/config", jsonpath="{.metadata.annotations.minio_host}")
+cm_minio_url = kube.kubectl("get", f"cm/config", jsonpath="{.metadata.annotations.s3_host}")
 assert(cm_minio_url)
 assert(minio.delete())


### PR DESCRIPTION
This PR removes MINIO_ variables from user metadata replacing them with the corresponding S3_ taking into account that ops bucket related tasks are using exclusively the S3_ ones