### PR TITLE
CouchDb and Ingress updates

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Kind
         uses: container-tools/kind-action@v2.0.4
         with:
-              version: v0.17.0
+              version: v0.22.0
               cluster_name: nuvolaris
               config: .github/kind.yaml 
       - name: Setup

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Kind
         uses: container-tools/kind-action@v2.0.4
         with:
-            version: v0.17.0
+            version: v0.22.0
             cluster_name: nuvolaris
             config: .github/kind.yaml        
       - name: Install

--- a/nuvolaris/templates/couchdb-init.yaml
+++ b/nuvolaris/templates/couchdb-init.yaml
@@ -33,7 +33,11 @@ spec:
         whisks.nuvolaris.org/annotate-version: "true"
     spec:
       serviceAccount: nuvolaris-operator
-      restartPolicy: Never      
+      restartPolicy: Never
+      initContainers:
+      - name: check-couchdb
+        image: busybox:1.36.0
+        command: ["sh", "-c", 'result=1; until [ $result -eq 0 ]; do OK=$(wget -qO - http://couchdb:5984 | grep "Welcome"); if [ "$OK" ]; then result=0; echo "Couchdb returned welcome!"; else echo waiting for Couchdb to be ready; sleep 5; fi; done; echo "Success: couchdb is up"']
       containers:
       - name: init-couchdb
         image: "{{image}}"

--- a/nuvolaris/templates/generic-ingress-tpl.yaml
+++ b/nuvolaris/templates/generic-ingress-tpl.yaml
@@ -23,7 +23,6 @@ metadata:
   namespace: {{namespace}}
   annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: "1024m"
-      kubernetes.io/ingress.class: "{{ingress_class}}"
       {% if tls %}
       cert-manager.io/cluster-issuer: "letsencrypt-issuer"
       {% endif %}
@@ -48,6 +47,7 @@ metadata:
       traefik.ingress.kubernetes.io/router.middlewares: nuvolaris-{{middleware_ingress_name}}@kubernetescrd
       {% endif %}
 spec:
+  ingressClassName: "{{ingress_class}}"
   {% if tls %}
   tls:
     - hosts:

--- a/tests/couchdb_test.ipy
+++ b/tests/couchdb_test.ipy
@@ -31,4 +31,4 @@ cdb.create(None)
 r = !kubectl -n nuvolaris wait --for=condition=complete job/couchdb-init --timeout=600s
 assert(r[0].find("condition met") != -1)
 r = !kubectl -n nuvolaris logs -l job=couchdb-init | grep "OK: enable_db_compaction: subjects"
-assert(r[0].find("OK:") != -1)
+assert(r[1].find("OK:") != -1)


### PR DESCRIPTION
This PR contributes following enhancement to the OpenServerless operator

- using ingressClassName into ingresses specs to solve K8s deprecation warning messages
- introduces CouchDB readiness check into couchdb-init job to prevent misleading error statuses in corresponding jobs
- Uses kind v0.22.0 in GitHub actions leveraging kind k8s version 1.29.2. 

this PR will require upgrades to OPS kind related task to upgrade kind version accordingly.