### PR TITLE
fix: added secrets to whisk-system

### DIFF
--- a/whisk-system.sh
+++ b/whisk-system.sh
@@ -28,6 +28,11 @@ cd ${HOME}/actions/login
 rm  -f ${HOME}/deploy/whisk-system/login.zip
 zip -r ${HOME}/deploy/whisk-system/login.zip *
 
+cp ${HOME}/nuvolaris/config.py ${HOME}/nuvolaris/couchdb_util.py ${HOME}/nuvolaris/user_config.py ${HOME}/actions/secrets/nuvolaris
+cd ${HOME}/actions/secrets
+rm  -f ${HOME}/deploy/whisk-system/secrets.zip
+zip -r ${HOME}/deploy/whisk-system/secrets.zip *
+
 cd ${HOME}/actions/content
 mkdir -p ${HOME}/actions/content/common
 cp ${HOME}/actions/common/minio_util.py ${HOME}/actions/content/common


### PR DESCRIPTION
missed to add the secrets.zip to whisk-system.sh file used during the docker image build