### PR TITLE
chore(actions): wrong zip for whisk-system.sh

### DIFF
--- a/whisk-system.sh
+++ b/whisk-system.sh
@@ -28,6 +28,7 @@ cd ${HOME}/actions/login
 rm  -f ${HOME}/deploy/whisk-system/login.zip
 zip -r ${HOME}/deploy/whisk-system/login.zip *
 
+mkdir -p ${HOME}/actions/secrets/nuvolaris
 cp ${HOME}/nuvolaris/config.py ${HOME}/nuvolaris/couchdb_util.py ${HOME}/nuvolaris/user_config.py ${HOME}/actions/secrets/nuvolaris
 cd ${HOME}/actions/secrets
 rm  -f ${HOME}/deploy/whisk-system/secrets.zip


### PR DESCRIPTION
fixed a bug that in whisk-system.sh that caused a missing dependency for secrets system action