### PR TITLE
fix: apache/openserverless#108 postgres replicas set was ignored

### DIFF
--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -449,7 +449,7 @@ def get_postgres_config_data():
         'postgres_nuvolaris_user': "nuvolaris",
         'postgres_nuvolaris_password': cfg.get('postgres.nuvolaris.password') or "s0meP@ass3",
         'size': cfg.get('postgres.volume-size') or 10,
-        'replicas': cfg.get('postgres.admin.replicas') or 2,
+        'replicas': cfg.get('postgres.replicas') or 2,
         'storageClass': cfg.get('nuvolaris.storageclass'),
         'failover': cfg.get('postgres.failover') or False,
         'backup': cfg.get('postgres.backup.enabled') or False,


### PR DESCRIPTION
This PR fixes an issues reported in apache/openserverless#108. Postgres replicas was always defaulting to 2, as the configured values was retrieved from the wrong wsk config value.