### PR TITLE
chore: ensure default index.html deployed into namespace web bucket uses Apache OPS

### DIFF
--- a/deploy/content/index.html
+++ b/deploy/content/index.html
@@ -22,11 +22,11 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <title>Nuvolaris Static Content landing page</title>    
+    <title>Apache OpenServerless (incubating) Static Content landing page</title>    
 </head>
 <body>
     <p>
-        Welcome to Nuvolaris static content distributor landing page!!!
+        Welcome to Apache OpenServerless (incubating) static content distributor landing page!!!
     </p>
 </body>
 </html>

--- a/nuvolaris/templates/content.html
+++ b/nuvolaris/templates/content.html
@@ -19,7 +19,7 @@
 -->
 <html>
 <head>
-    <title>Welcome to Nuvolaris Content Example</title>
+    <title>Welcome to Apache OpenServerless (incubating) Content Example</title>
 </head>
 <body>
     <h1>This is another HTML page uploaded via upload action</h1>


### PR DESCRIPTION
This PR ensure that the default index.html deployed into namespaces web buckets mention Apache OpenServerless and not nuvolaris.