### PR TITLE
chore: missing license

### DIFF
--- a/tests/kind/runtimes_preloader_test.ipy
+++ b/tests/kind/runtimes_preloader_test.ipy
@@ -16,7 +16,6 @@
 # under the License.
 #
 import nuvolaris.config as cfg
-import nuvolaris.runtimes_preloader as preloader
 import nuvolaris.util as util
 import nuvolaris.runtimes_util as rutil
 import nuvolaris.testutil as tu
@@ -37,10 +36,6 @@ cleanup()
 
 # Test with Apache runtimes
 assert(cfg.configure(tu.load_sample_config()))
-assert(preloader.create())
-
-# Wait for the job to complete
-while not kube.wait("job.batch/preload-runtimes", "condition=complete"): pass
 
 runtimes_as_json = util.get_runtimes_json_from_config_map()
 data=rutil.parse_runtimes(json.loads(runtimes_as_json))
@@ -57,5 +52,5 @@ count_non_apache = len(data['containers']) - count_apache
 assert(count_apache > 0), "Expected at least one Apache runtime in the preloader data"
 assert(count_non_apache == 0), "Expected no non-Apache runtimes in the preloader data"
 
-assert(preloader.delete())
+
 cleanup()


### PR DESCRIPTION
fixed missing license header in runtimes_preloader_test.ipy