### PR TITLE
feat: extend nuvolaris-swku-role for adminapi

### DIFF
--- a/deploy/nuvolaris-permissions/nuvolaris-wsku-roles.yaml
+++ b/deploy/nuvolaris-permissions/nuvolaris-wsku-roles.yaml
@@ -29,6 +29,14 @@ rules:
 - apiGroups: ["nuvolaris.org"]
   resources: ["whisksusers","whisksusers/status","*/finalizers"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# assign the possibility to operate on configmaps (admin api)
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]  
+# assign the possibility to operate on jobs (admin api)
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
extend nuvolaris-swku-role for adminapi, adding permissions on configmaps and jobs.

@francescotimperi: please review this PR and let me know if there's a way to further restrict permissions