### PR TITLE
fix: ETCD volume size was not usin corresponding env variable if passsed

### DIFF
--- a/deploy/nuvolaris-permissions/whisk-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-crd.yaml
@@ -754,7 +754,11 @@ spec:
                             type: integer
                           ledgers:
                             description: pulsar bookie ledgers instance volume size
-                            type: integer                                                                                                                                     
+                            type: integer
+                          bucket:
+                            description: used to setup a quota on the S3 bucket when running under seaweedfs (default to 10240MB)
+                            type: integer                                                                                                                                                                 
+                            type: integer                                                                                                                                      
                     replicas:
                       description: number of total milvus replicas. Defaulted to 1
                       type: integer

--- a/deploy/nuvolaris-permissions/whisk-crd.yaml
+++ b/deploy/nuvolaris-permissions/whisk-crd.yaml
@@ -152,7 +152,7 @@ spec:
                       type: boolean
                     seaweedfs:
                       description: deploys an S3 compatible layer using a standalone deployment of seaweedfs
-                      type: boolean                                                                    
+                      type: boolean                                                                     
                   required:
                     - openwhisk
                     - couchdb
@@ -754,10 +754,7 @@ spec:
                             type: integer
                           ledgers:
                             description: pulsar bookie ledgers instance volume size
-                            type: integer 
-                          bucket:
-                            description: used to setup a quota on the S3 bucket when running under seaweedfs (default to 10240MB)
-                            type: integer                                                                                                                                                                 
+                            type: integer                                                                                                                                     
                     replicas:
                       description: number of total milvus replicas. Defaulted to 1
                       type: integer
@@ -997,4 +994,9 @@ spec:
           type: string
           priority: 0
           jsonPath: .status.whisk_create.registry
-          description: Registry                                                                                                              
+          description: Registry 
+        - name: Seaweedfs
+          type: string
+          priority: 0
+          jsonPath: .status.whisk_create.seaweedfs
+          description: Seaweedfs                                                                                                                        

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -761,7 +761,7 @@ def get_etcd_config_data():
         "applypodsecurity":get_enable_pod_security(),
         "name": "nuvolaris-etcd",
         "container": "nuvolaris-etcd",
-        "size": cfg.get("etcd.volume-size", "REDIS_VOLUME_SIZE", 5),
+        "size": cfg.get("etcd.volume-size", "STORAGE_SIZE_ETCD", 5),
         "storageClass": cfg.get("nuvolaris.storageclass"),
         "root_password":cfg.get("etcd.root.password") or "s0meP@ass3wd",
         "etcd_replicas":get_etcd_replica(),


### PR DESCRIPTION
this simple PR fixes a glitch into the config parameter used for ETCD as it was using an env variable used for REDIS .