### PR TITLE
Support Openwhisk2 based images 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,10 +104,10 @@ FROM python:3.12-slim-bullseye
 
 ARG OPERATOR_IMAGE_DEFAULT=registry.hub.docker.com/apache/openserverless-operator
 ARG OPERATOR_TAG_DEFAULT=0.1.0-testing.2309191654
-ENV CONTROLLER_IMAGE=ghcr.io/ftimperioss/openserverless-wsk-controller
-ENV CONTROLLER_TAG=2.0.0-incubating.2512131645
-ENV INVOKER_IMAGE=ghcr.io/ftimperioss/openserverless-wsk-invoker
-ENV INVOKER_TAG=2.0.0-incubating.2512131645
+ENV CONTROLLER_IMAGE=registry.hub.docker.com/apache/openserverless-wsk-controller
+ENV CONTROLLER_TAG=2.0.0-incubating.2512132233
+ENV INVOKER_IMAGE=registry.hub.docker.com/apache/openserverless-wsk-invoker
+ENV INVOKER_TAG=2.0.0-incubating.2512132233
 ENV OPERATOR_IMAGE=${OPERATOR_IMAGE_DEFAULT}
 ENV OPERATOR_TAG=${OPERATOR_TAG_DEFAULT}
 ENV TZ=Europe/London

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,10 +104,10 @@ FROM python:3.12-slim-bullseye
 
 ARG OPERATOR_IMAGE_DEFAULT=registry.hub.docker.com/apache/openserverless-operator
 ARG OPERATOR_TAG_DEFAULT=0.1.0-testing.2309191654
-ENV CONTROLLER_IMAGE=ghcr.io/nuvolaris/openwhisk-controller
-ENV CONTROLLER_TAG=3.1.0-mastrogpt.2402101445
-ENV INVOKER_IMAGE=ghcr.io/nuvolaris/openwhisk-invoker
-ENV INVOKER_TAG=3.1.0-mastrogpt.2402101445
+ENV CONTROLLER_IMAGE=ghcr.io/ftimperioss/openserverless-wsk-controller
+ENV CONTROLLER_TAG=2.0.0-incubating.2512131645
+ENV INVOKER_IMAGE=ghcr.io/ftimperioss/openserverless-wsk-invoker
+ENV INVOKER_TAG=2.0.0-incubating.2512131645
 ENV OPERATOR_IMAGE=${OPERATOR_IMAGE_DEFAULT}
 ENV OPERATOR_TAG=${OPERATOR_TAG_DEFAULT}
 ENV TZ=Europe/London

--- a/deploy/openwhisk-invoker/invoker-sts.yaml
+++ b/deploy/openwhisk-invoker/invoker-sts.yaml
@@ -91,10 +91,10 @@ spec:
           - name: "JAVA_OPTS"
             value: "-Xmx512M "
 
-          # Invoker options
-          - name: "INVOKER_OPTS"
-            value: " -Dkubernetes.master=https://$KUBERNETES_SERVICE_HOST -Dwhisk.spi.ContainerFactoryProvider=org.apache.openwhisk.core.containerpool.kubernetes.KubernetesContainerFactoryProvider"
-
+          # Invoker options          
+          #- name: "INVOKER_OPTS"
+          #  value: "-Dkubernetes.master=https://$KUBERNETES_SERVICE_HOST" 
+          
           # action runtimes
           - name: "RUNTIMES_MANIFEST"
             valueFrom:   

--- a/deploy/zookeeper/zookeeper-000-cm.yaml
+++ b/deploy/zookeeper/zookeeper-000-cm.yaml
@@ -27,12 +27,15 @@ data:
   zoo.cfg: |
     tickTime=2000
     clientPort=2181
-    initLimit=5
-    syncLimit=2
+    initLimit=10
+    syncLimit=5
     dataDir=/data
     dataLogDir=/datalog
-    logLevel=INFO
-    server.0=zookeeper-0.zookeeper:2888:3888  
+    maxClientCnxns=60
+    autopurge.snapRetainCount=3
+    autopurge.purgeInterval=24
+    server.1=zookeeper-0.zookeeper:2888:3888
+    4lw.commands.whitelist=ruok
 
   log4j.properties: |+
     #

--- a/deploy/zookeeper/zookeeper-003-sts.yaml
+++ b/deploy/zookeeper/zookeeper-003-sts.yaml
@@ -25,7 +25,6 @@ metadata:
     app: zookeeper
 spec:
   serviceName: zookeeper
-  podManagementPolicy: "Parallel"
   replicas: 1
   selector:
     matchLabels:
@@ -48,20 +47,49 @@ spec:
         - name: "zookeeper-pvc-datalog"
           persistentVolumeClaim:
             claimName: "zookeeper-pvc-datalog"
-      
+
+      initContainers:
+      - name: init-myid
+        image: busybox
+        command:
+          - sh
+          - -c
+          - |
+            mkdir -p /data /datalog
+            echo 1 > /data/myid
+            chown -R 1001:1001 /data /datalog
+        volumeMounts:
+          - name: zookeeper-pvc-data
+            mountPath: /data
+          - name: zookeeper-pvc-datalog
+            mountPath: /datalog
+          - name: zk-config
+            mountPath: /conf
+
       containers:
       - name: zookeeper
-        image: "ghcr.io/nuvolaris/zookeeper:3.4.14"
-        imagePullPolicy: "IfNotPresent"
-        command: ["/bin/bash", "-c", "hostname -s | awk -F '-' '{print $NF}'> /data/myid; cat /data/myid; cat /conf/zoo.cfg; zkServer.sh start-foreground"]
+        image: zookeeper:3.5.9
+        imagePullPolicy: IfNotPresent
+        command:
+          - sh
+          - -c
+          - |
+            export ZOOCFGDIR=/conf
+            zkServer.sh start-foreground
         ports:
-        - name: zookeeper
-          containerPort: 2181
-        - name: server
-          containerPort: 2888
-        - name: leader-election
-          containerPort: 3888
-
+          - name: zookeeper
+            containerPort: 2181
+          - name: quorum
+            containerPort: 2888
+          - name: leader-election
+            containerPort: 3888
+        volumeMounts:
+          - name: zk-config
+            mountPath: /conf
+          - name: zookeeper-pvc-data
+            mountPath: /data
+          - name: zookeeper-pvc-datalog
+            mountPath: /datalog
         livenessProbe:
           tcpSocket:
             port: 2181
@@ -71,17 +99,9 @@ spec:
         readinessProbe:
           exec:
             command:
-            - /bin/bash
-            - -c
-            - "echo ruok | nc -w 1 localhost 2181 | grep imok"
+              - sh
+              - -c
+              - "zkServer.sh status"
           initialDelaySeconds: 5
           periodSeconds: 10
-          timeoutSeconds: 1
-        volumeMounts:
-        - mountPath: /conf
-          name: zk-config         
-        - mountPath: /data
-          name: "zookeeper-pvc-data"
-        - mountPath: /datalog
-          name: "zookeeper-pvc-datalog"
----
+          timeoutSeconds: 3

--- a/nuvolaris/enterprise_util.py
+++ b/nuvolaris/enterprise_util.py
@@ -45,7 +45,7 @@ def get_invoker_image_data(data):
         data['invoker_tag'] = img_data["tag"]
     else:        
         data['invoker_image'] = cfg.get("invoker.image","INVOKER_IMAGE","apache/openserverless-wsk-invoker")
-        data['invoker_tag'] = cfg.get("invoker.tag","INVOKER_TAG","2.0.0-incubating.2506080813")
+        data['invoker_tag'] = cfg.get("invoker.tag","INVOKER_TAG","2.0.0-incubating.2512132233")
 
 def getEnterpriseControllerConfigData():
     data = {

--- a/nuvolaris/enterprise_util.py
+++ b/nuvolaris/enterprise_util.py
@@ -44,8 +44,8 @@ def get_invoker_image_data(data):
         data['invoker_image'] = img_data["image"]
         data['invoker_tag'] = img_data["tag"]
     else:        
-        data['invoker_image'] = cfg.get("invoker.image") or "ghcr.io/nuvolaris/openwhisk-invoker"
-        data['invoker_tag'] = cfg.get("invoker.tag") or "3.1.0-mastrogpt.2402101445"    
+        data['invoker_image'] = cfg.get("invoker.image","INVOKER_IMAGE","apache/openserverless-wsk-invoker")
+        data['invoker_tag'] = cfg.get("invoker.tag","INVOKER_TAG","2.0.0-incubating.2506080813")
 
 def getEnterpriseControllerConfigData():
     data = {

--- a/nuvolaris/invoker.py
+++ b/nuvolaris/invoker.py
@@ -39,9 +39,8 @@ def create(owner=None):
     if(data['affinity'] or data['tolerations']):
        tplp.append("affinity-tolerance-sts-invoker-attach.yaml")
     
-    logging.info(f"using invoker image {whisk_image}:{whisk_tag}")
-    config = kus.image(whisk_image, newTag=whisk_tag)
-    config += kus.patchTemplates("openwhisk-invoker", tplp, data)
+    logging.info(f"using invoker image {whisk_image}:{whisk_tag}")    
+    config = kus.patchTemplates("openwhisk-invoker", tplp, data)
     spec = kus.kustom_list("openwhisk-invoker", config, templates=[], data=data)
 
     if owner:

--- a/nuvolaris/invoker.py
+++ b/nuvolaris/invoker.py
@@ -39,6 +39,7 @@ def create(owner=None):
     if(data['affinity'] or data['tolerations']):
        tplp.append("affinity-tolerance-sts-invoker-attach.yaml")
     
+    logging.info(f"using invoker image {whisk_image}:{whisk_tag}")
     config = kus.image(whisk_image, newTag=whisk_tag)
     config += kus.patchTemplates("openwhisk-invoker", tplp, data)
     spec = kus.kustom_list("openwhisk-invoker", config, templates=[], data=data)

--- a/nuvolaris/openwhisk_enterprise.py
+++ b/nuvolaris/openwhisk_enterprise.py
@@ -36,9 +36,8 @@ def create(owner=None):
     if(data['affinity'] or data['tolerations']):
        tplp.append("affinity-tolerance-sts-core-attach.yaml")    
 
-    logging.info(f"using controller image {whisk_image}:{whisk_tag}")
-    config = kus.image(whisk_image, newTag=whisk_tag)
-    config += kus.patchTemplates("openwhisk-enterprise", tplp, data)
+    logging.info(f"using controller image {whisk_image}:{whisk_tag}")   
+    config = kus.patchTemplates("openwhisk-enterprise", tplp, data)
     spec = kus.kustom_list("openwhisk-enterprise", config, templates=[], data=data)
     
     if owner:

--- a/nuvolaris/openwhisk_enterprise.py
+++ b/nuvolaris/openwhisk_enterprise.py
@@ -36,6 +36,7 @@ def create(owner=None):
     if(data['affinity'] or data['tolerations']):
        tplp.append("affinity-tolerance-sts-core-attach.yaml")    
 
+    logging.info(f"using controller image {whisk_image}:{whisk_tag}")
     config = kus.image(whisk_image, newTag=whisk_tag)
     config += kus.patchTemplates("openwhisk-enterprise", tplp, data)
     spec = kus.kustom_list("openwhisk-enterprise", config, templates=[], data=data)

--- a/nuvolaris/openwhisk_standalone.py
+++ b/nuvolaris/openwhisk_standalone.py
@@ -32,14 +32,13 @@ def create(owner=None):
     whisk_image = data["controller_image"]
     whisk_tag = data["controller_tag"]
 
-    logging.info(f"using controller image {whisk_image}:{whisk_tag}")
-    config = kus.image(whisk_image, newTag=whisk_tag)
+    logging.info(f"using controller image {whisk_image}:{whisk_tag}")    
     
     tplp = ["standalone-sts.yaml"]
     if(data['affinity'] or data['tolerations']):
        tplp.append("affinity-tolerance-sts-core-attach.yaml")
 
-    config += kus.patchTemplates("openwhisk-standalone", tplp, data)
+    config = kus.patchTemplates("openwhisk-standalone", tplp, data)
     spec = kus.kustom_list("openwhisk-standalone", config, templates=[], data=data)
 
     if owner:

--- a/nuvolaris/openwhisk_standalone.py
+++ b/nuvolaris/openwhisk_standalone.py
@@ -31,6 +31,8 @@ def create(owner=None):
 
     whisk_image = data["controller_image"]
     whisk_tag = data["controller_tag"]
+
+    logging.info(f"using controller image {whisk_image}:{whisk_tag}")
     config = kus.image(whisk_image, newTag=whisk_tag)
     
     tplp = ["standalone-sts.yaml"]

--- a/nuvolaris/templates/enterprise-sts.yaml
+++ b/nuvolaris/templates/enterprise-sts.yaml
@@ -229,9 +229,19 @@ spec:
         - name: "CONFIG_kamon_metric_tickInterval"
           value: "30"        
 
-        #- name: "CONFIG_spi_ContainerFactoryProvider"
-        #  value: "org.apache.openwhisk.core.containerpool.kubernetes.KubernetesContainerFactoryProvider"
-        #- name: "CONFIG_spi_LogStoreProvider"
-        #  value:  "org.apache.openwhisk.core.containerpool.logging.DockerToActivationLogStoreProvider"           
-        #- name: "CONFIG_spi_ArtifactStoreProvider"
-        #  value: "org.apache.openwhisk.core.database.CouchDbStoreProvider"       
+        # OpenWhisk 2 without Scheduler
+        - name: "CONFIG_spi_LoadBalancerProvider"
+          value: "org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
+        - name: "CONFIG_spi_EntitlementSpiProvider"
+          value: "org.apache.openwhisk.core.entitlement.LocalEntitlementProvider"      
+        - name: "CONFIG_spi_LoadBalancerProvider"
+          value: "org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
+        - name: "CONFIG_spi_InvokerProvider"
+          value: "org.apache.openwhisk.core.invoker.InvokerReactive"
+        - name: "CONFIG_spi_InvokerServerProvider"
+          value: "org.apache.openwhisk.core.invoker.DefaultInvokerServer"
+        - name: "CONFIG_spi_DurationCheckerProvider"
+          value: "org.apache.openwhisk.core.scheduler.queue.NoopDurationCheckerProvider"
+
+
+

--- a/nuvolaris/templates/enterprise-sts.yaml
+++ b/nuvolaris/templates/enterprise-sts.yaml
@@ -48,7 +48,7 @@ spec:
       containers:
       - name: controller
         imagePullPolicy: "IfNotPresent"
-        image: "ghcr.io/nuvolaris/openwhisk-controller:0.3.0-morpheus.22122609"      
+        image: "{{controller_image}}:{{controller_tag}}"      
         command: ["/bin/bash", "-c", "/init.sh `hostname | awk -F '-' '{print $NF}'`"]     
         ports:
         - name: controller
@@ -230,17 +230,17 @@ spec:
           value: "30"        
 
         # OpenWhisk 2 without Scheduler
-        - name: "CONFIG_spi_LoadBalancerProvider"
+        - name: "CONFIG_whisk_spi_LoadBalancerProvider"
           value: "org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
-        - name: "CONFIG_spi_EntitlementSpiProvider"
+        - name: "CONFIG_whisk_spi_EntitlementSpiProvider"
           value: "org.apache.openwhisk.core.entitlement.LocalEntitlementProvider"      
-        - name: "CONFIG_spi_LoadBalancerProvider"
+        - name: "CONFIG_whisk_spi_LoadBalancerProvider"
           value: "org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
-        - name: "CONFIG_spi_InvokerProvider"
+        - name: "CONFIG_whisk_spi_InvokerProvider"
           value: "org.apache.openwhisk.core.invoker.InvokerReactive"
-        - name: "CONFIG_spi_InvokerServerProvider"
+        - name: "CONFIG_whisk_spi_InvokerServerProvider"
           value: "org.apache.openwhisk.core.invoker.DefaultInvokerServer"
-        - name: "CONFIG_spi_DurationCheckerProvider"
+        - name: "CONFIG_whisk_spi_DurationCheckerProvider"
           value: "org.apache.openwhisk.core.scheduler.queue.NoopDurationCheckerProvider"
 
 

--- a/nuvolaris/templates/invoker-sts.yaml
+++ b/nuvolaris/templates/invoker-sts.yaml
@@ -306,7 +306,22 @@ spec:
           {% if usePrivateRegistry %}
           - name: "CONFIG_whisk_kubernetes_podTemplate"
             value: "file:/templates/ow_pod_templates.yaml"
-          {% endif %}              
+          {% endif %}
+
+          # OpenWhisk 2 without Scheduler
+          - name: "CONFIG_spi_LoadBalancerProvider"
+            value: "org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
+          - name: "CONFIG_spi_EntitlementSpiProvider"
+            value: "org.apache.openwhisk.core.entitlement.LocalEntitlementProvider"      
+          - name: "CONFIG_spi_LoadBalancerProvider"
+            value: "org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
+          - name: "CONFIG_spi_InvokerProvider"
+            value: "org.apache.openwhisk.core.invoker.InvokerReactive"
+          - name: "CONFIG_spi_InvokerServerProvider"
+            value: "org.apache.openwhisk.core.invoker.DefaultInvokerServer"
+          - name: "CONFIG_spi_DurationCheckerProvider"
+            value: "org.apache.openwhisk.core.scheduler.queue.NoopDurationCheckerProvider"
+
 
         ports:
         - name: invoker

--- a/nuvolaris/templates/invoker-sts.yaml
+++ b/nuvolaris/templates/invoker-sts.yaml
@@ -47,7 +47,7 @@ spec:
         command: ['sh', '-c', "until nslookup kafka.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for kafka; sleep 2; done"]     
       containers:
       - name: invoker
-        image: "ghcr.io/nuvolaris/openwhisk-invoker:0.3.0-morpheus.22122609"
+        image: "{{invoker_image}}:{{invoker_tag}}"
         imagePullPolicy: "IfNotPresent"
         command: [ "/bin/bash", "-c", "/init.sh --uniqueName $INVOKER_NAME" ]
         #command: ["sleep", "inf"]
@@ -103,8 +103,8 @@ spec:
             value: "{{invoker_java_opts}} "
 
           # Invoker options          
-          - name: "INVOKER_OPTS"
-            value: "-Dkubernetes.master=https://$KUBERNETES_SERVICE_HOST -Dwhisk.spi.ContainerFactoryProvider=org.apache.openwhisk.core.containerpool.kubernetes.KubernetesContainerFactoryProvider"           
+          #- name: "INVOKER_OPTS"
+          #  value: "-Dkubernetes.master=https://$KUBERNETES_SERVICE_HOST"           
 
           # action runtimes
           - name: "RUNTIMES_MANIFEST"
@@ -309,18 +309,22 @@ spec:
           {% endif %}
 
           # OpenWhisk 2 without Scheduler
-          - name: "CONFIG_spi_LoadBalancerProvider"
+          - name: "CONFIG_whisk_spi_LoadBalancerProvider"
             value: "org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
-          - name: "CONFIG_spi_EntitlementSpiProvider"
+          - name: "CONFIG_whisk_spi_EntitlementSpiProvider"
             value: "org.apache.openwhisk.core.entitlement.LocalEntitlementProvider"      
-          - name: "CONFIG_spi_LoadBalancerProvider"
+          - name: "CONFIG_whisk_spi_LoadBalancerProvider"
             value: "org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
-          - name: "CONFIG_spi_InvokerProvider"
+          - name: "CONFIG_whisk_spi_InvokerProvider"
             value: "org.apache.openwhisk.core.invoker.InvokerReactive"
-          - name: "CONFIG_spi_InvokerServerProvider"
+          - name: "CONFIG_whisk_spi_InvokerServerProvider"
             value: "org.apache.openwhisk.core.invoker.DefaultInvokerServer"
-          - name: "CONFIG_spi_DurationCheckerProvider"
+          - name: "CONFIG_whisk_spi_DurationCheckerProvider"
             value: "org.apache.openwhisk.core.scheduler.queue.NoopDurationCheckerProvider"
+
+          # kubernetes
+          - name: "CONFIG_whisk_spi_ContainerFactoryProvider"
+            value: "org.apache.openwhisk.core.containerpool.kubernetes.KubernetesContainerFactoryProvider"            
 
 
         ports:

--- a/nuvolaris/templates/standalone-sts.yaml
+++ b/nuvolaris/templates/standalone-sts.yaml
@@ -45,7 +45,7 @@ spec:
       containers:
       - name: controller
         imagePullPolicy: "IfNotPresent"
-        image: "ghcr.io/nuvolaris/openwhisk-controller:0.3.0-morpheus.22122609"       
+        image: "{{controller_image}}:{{controller_tag}}"
         command: ["/bin/bash", "-c", "/init.sh `hostname | awk -F '-' '{print $NF}'`"]             
         ports:
         - name: controller
@@ -219,15 +219,19 @@ spec:
           value: "org.apache.openwhisk.core.containerpool.logging.DockerToActivationLogStoreProvider"
 
         # OpenWhisk 2 without Scheduler
-        - name: "CONFIG_spi_EntitlementSpiProvider"
-          value: "org.apache.openwhisk.core.entitlement.LocalEntitlementProvider"      
-        - name: "CONFIG_spi_LoadBalancerProvider"
+        - name: "CONFIG_whisk_spi_EntitlementSpiProvider"
+          value: "org.apache.openwhisk.core.entitlement.LocalEntitlementProvider"
+
+        - name: "CONFIG_whisk_spi_LoadBalancerProvider"
           value: "org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
-        - name: "CONFIG_spi_InvokerProvider"
+
+        - name: "CONFIG_whisk_spi_InvokerProvider"
           value: "org.apache.openwhisk.core.invoker.InvokerReactive"
-        - name: "CONFIG_spi_InvokerServerProvider"
+
+        - name: "CONFIG_whisk_spi_InvokerServerProvider"
           value: "org.apache.openwhisk.core.invoker.DefaultInvokerServer"
-        - name: "CONFIG_spi_DurationCheckerProvider"
+
+        - name: "CONFIG_whisk_spi_DurationCheckerProvider"
           value: "org.apache.openwhisk.core.scheduler.queue.NoopDurationCheckerProvider"
 
         - name: "CONFIG_whisk_controller_protocol"

--- a/nuvolaris/templates/standalone-sts.yaml
+++ b/nuvolaris/templates/standalone-sts.yaml
@@ -216,7 +216,19 @@ spec:
           value: "org.apache.openwhisk.core.containerpool.kubernetes.KubernetesContainerFactoryProvider"             
 
         - name: "CONFIG_whisk_spi_LogStoreProvider"
-          value: "org.apache.openwhisk.core.containerpool.logging.DockerToActivationLogStoreProvider"           
+          value: "org.apache.openwhisk.core.containerpool.logging.DockerToActivationLogStoreProvider"
+
+        # OpenWhisk 2 without Scheduler
+        - name: "CONFIG_spi_EntitlementSpiProvider"
+          value: "org.apache.openwhisk.core.entitlement.LocalEntitlementProvider"      
+        - name: "CONFIG_spi_LoadBalancerProvider"
+          value: "org.apache.openwhisk.core.loadBalancer.ShardingContainerPoolBalancer"
+        - name: "CONFIG_spi_InvokerProvider"
+          value: "org.apache.openwhisk.core.invoker.InvokerReactive"
+        - name: "CONFIG_spi_InvokerServerProvider"
+          value: "org.apache.openwhisk.core.invoker.DefaultInvokerServer"
+        - name: "CONFIG_spi_DurationCheckerProvider"
+          value: "org.apache.openwhisk.core.scheduler.queue.NoopDurationCheckerProvider"
 
         - name: "CONFIG_whisk_controller_protocol"
           value: "http"  

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -302,8 +302,8 @@ def get_controller_image_data(data):
         data['controller_image'] = img_data["image"]
         data['controller_tag'] = img_data["tag"]
     else:
-        data['controller_image'] = cfg.get("controller.image") or "ghcr.io/nuvolaris/openwhisk-controller"
-        data['controller_tag'] = cfg.get("controller.tag") or "3.1.0-mastrogpt.2402101445"
+        data['controller_image'] = cfg.get("controller.image","CONTROLLER_IMAGE","apache/openserverless-wsk-controller")
+        data['controller_tag'] = cfg.get("controller.tag","CONTROLLER_TAG","2.0.0-incubating.2506080813")
 
 # return configuration parameters for the standalone controller
 def get_standalone_config_data():

--- a/nuvolaris/util.py
+++ b/nuvolaris/util.py
@@ -303,7 +303,7 @@ def get_controller_image_data(data):
         data['controller_tag'] = img_data["tag"]
     else:
         data['controller_image'] = cfg.get("controller.image","CONTROLLER_IMAGE","apache/openserverless-wsk-controller")
-        data['controller_tag'] = cfg.get("controller.tag","CONTROLLER_TAG","2.0.0-incubating.2506080813")
+        data['controller_tag'] = cfg.get("controller.tag","CONTROLLER_TAG","2.0.0-incubating.2512132233")
 
 # return configuration parameters for the standalone controller
 def get_standalone_config_data():

--- a/nuvolaris/zookeeper.py
+++ b/nuvolaris/zookeeper.py
@@ -39,7 +39,7 @@ def get_zookeeper_connect_data():
     return None    
 
 def create(owner=None):
-    logging.info(f"*** configuring zookeeper")
+    logging.info("*** configuring zookeeper")
 
     data = cfg_util.get_zookeeper_config_data()
     

--- a/tests/kafka_test.ipy
+++ b/tests/kafka_test.ipy
@@ -34,7 +34,7 @@ pod_name = zookeeper.get_zookeeper_pod_name()
 assert(pod_name)
 
 zookeeper_version = kube.kubectl("get", f"pods/{pod_name}", jsonpath="{.spec.containers[0].image}")
-assert(zookeeper_version[0] == "ghcr.io/nuvolaris/zookeeper:3.4.14")
+assert(zookeeper_version[0] == "zookeeper:3.5.9")
 
 # check the url is stored into the configuration
 assert(cfg.get("nuvolaris.zookeeper.url") == "zookeeper-0.zookeeper:2181")

--- a/tests/kind/whisk-minimal.yaml
+++ b/tests/kind/whisk-minimal.yaml
@@ -25,11 +25,11 @@ spec:
     # start openwhisk controller
     openwhisk: true
     # start openwhisk invoker
-    invoker: false    
+    invoker: true    
     # start couchdb
     couchdb: true
     # start kafka
-    kafka: false
+    kafka: true
     # start mongodb
     mongodb: false
     # start redis

--- a/tests/kind/whisk-minimal.yaml
+++ b/tests/kind/whisk-minimal.yaml
@@ -30,6 +30,8 @@ spec:
     couchdb: true
     # start kafka
     kafka: true
+    # zookeeper enabled or not
+    zookeeper: true    
     # start mongodb
     mongodb: false
     # start redis

--- a/tests/kind/whisk-slim.yaml
+++ b/tests/kind/whisk-slim.yaml
@@ -47,9 +47,9 @@ spec:
     # postgres enabled or not
     postgres: true
     # etcd enabled or not
-    etcd: true
+    etcd: false
     # milvus enabled or not
-    milvus: true
+    milvus: false
     # registry enabled or not
     registry: false
     # seaweedfs enabled or not

--- a/tests/kind/whisk-slim.yaml
+++ b/tests/kind/whisk-slim.yaml
@@ -41,7 +41,7 @@ spec:
     # tls enabled or not
     tls: false
     # minio enabled or not
-    minio: true 
+    minio: false 
     # minio static enabled or not
     static: true
     # postgres enabled or not
@@ -53,7 +53,7 @@ spec:
     # registry enabled or not
     registry: false
     # seaweedfs enabled or not
-    seaweedfs: false               
+    seaweedfs: true               
   openwhisk:
     namespaces:
       whisk-system: 789c46b1-71f6-4ed5-8c54-816aa4f8c502:abczO3xZCLrMN6v2BKK1dXYFpXlPkccOFqm12CdAsMgRU4VrNZ9lyGVCGuMDGIwP

--- a/tests/zookeeper_test.ipy
+++ b/tests/zookeeper_test.ipy
@@ -32,7 +32,7 @@ pod_name = zookeeper.get_zookeeper_pod_name()
 assert(pod_name)
 
 zookeeper_version = kube.kubectl("get", f"pods/{pod_name}", jsonpath="{.spec.containers[0].image}")
-assert(zookeeper_version[0] == "ghcr.io/nuvolaris/zookeeper:3.4.14")
+assert(zookeeper_version[0] == "zookeeper:3.5.9")
 
 # check the url is stored into the configuration
 assert(cfg.get("nuvolaris.zookeeper.url") == "zookeeper-0.zookeeper:2181")


### PR DESCRIPTION
This PR contributes the minimal required changes to execute Openserverless against Openwhisk2 images generated via the openserverless-build.
It contributes:

1. Controller and Invoker based on latest Openwhisk source code, including a patch required to make the invoker working without the scheduler. The images are pushed on the official apache ops docker hub account
2. A fix to take into account the configured invoker and controller images (in the wsk/controller or in the operator image env variable)
3. The necessary changes to configure the OW2 controller and invoker to be able to work without the scheduler.

Do not forget that OW2 by default uses the scheduler, which is not currently configured by the ops operator.

This PR is meant to show the relevant changes needed to use the latest OW2 based images.