### PR TITLE
Update Kubegres image registry

### DIFF
--- a/deploy/postgres-operator/kubegres-operator.yaml
+++ b/deploy/postgres-operator/kubegres-operator.yaml
@@ -88,7 +88,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+        image: registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.14.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
The previous registry has been completely dismissed. Use the official `registry.k8s.io` instead.