### PR TITLE
Update Traefik API version

### DIFF
--- a/deploy/nuvolaris-permissions/operator-roles.yaml
+++ b/deploy/nuvolaris-permissions/operator-roles.yaml
@@ -83,7 +83,7 @@ rules:
   verbs: ["get","patch","list","update","watch","create","delete"]
 
 # required for traefik middlewares
-- apiGroups: ["traefik.containo.us"]
+- apiGroups: ["traefik.io"]
   resources: ["middlewares"]
   verbs: ["get","patch","list","update","watch","create","delete"]
 

--- a/nuvolaris/endpoint.py
+++ b/nuvolaris/endpoint.py
@@ -240,11 +240,11 @@ def delete(owner=None):
             return res
 
         if(ingress_class == 'traefik'):            
-            res = kube.kubectl("delete", "middleware.traefik.containo.us",api_middleware_ingress_name(namespace,"apihost"))
-            res += kube.kubectl("delete", "middleware.traefik.containo.us",api_middleware_ingress_name(namespace,"apihost-my"))
-            res += kube.kubectl("delete", "middleware.traefik.containo.us",api_middleware_ingress_name(namespace,"apihost-info"))
+            res = kube.kubectl("delete", "middleware.traefik.io",api_middleware_ingress_name(namespace,"apihost"))
+            res += kube.kubectl("delete", "middleware.traefik.io",api_middleware_ingress_name(namespace,"apihost-my"))
+            res += kube.kubectl("delete", "middleware.traefik.io",api_middleware_ingress_name(namespace,"apihost-info"))
             if should_delete_www:
-                res += kube.kubectl("delete", "middleware.traefik.containo.us",api_middleware_ingress_name(namespace,"apihost-www-my"))          
+                res += kube.kubectl("delete", "middleware.traefik.io",api_middleware_ingress_name(namespace,"apihost-www-my"))
 
         res += kube.kubectl("delete", "ingress",api_ingress_name(namespace,"apihost"))
         res += kube.kubectl("delete", "ingress",api_ingress_name(namespace,"apihost-my"))
@@ -321,8 +321,8 @@ def delete_ow_api_endpoint(ucfg):
             return res
 
         if(ingress_class == 'traefik'):                        
-            res += kube.kubectl("delete", "middleware.traefik.containo.us",api_middleware_ingress_name(namespace,"apihost"))
-            res += kube.kubectl("delete", "middleware.traefik.containo.us",api_middleware_ingress_name(namespace,"apihost-my"))             
+            res += kube.kubectl("delete", "middleware.traefik.io",api_middleware_ingress_name(namespace,"apihost"))
+            res += kube.kubectl("delete", "middleware.traefik.io",api_middleware_ingress_name(namespace,"apihost-my"))
 
         res += kube.kubectl("delete", "ingress",api_ingress_name(namespace,"apihost"))
         res += kube.kubectl("delete", "ingress",api_ingress_name(namespace,"apihost-my"))

--- a/nuvolaris/minio_ingress.py
+++ b/nuvolaris/minio_ingress.py
@@ -203,7 +203,7 @@ def delete_minio_ingress(runtime, namespace, ingress_class, type, owner=None):
         res += kube.kubectl("delete", "ingress",endpoint.api_ingress_name(namespace,type))    
 
         if(ingress_class == 'traefik'):            
-            res = kube.kubectl("delete", "middleware.traefik.containo.us",endpoint.api_middleware_ingress_name(namespace,type))         
+            res = kube.kubectl("delete", "middleware.traefik.io",endpoint.api_middleware_ingress_name(namespace,type))
 
         return res
     except Exception as e:

--- a/nuvolaris/registry_deploy.py
+++ b/nuvolaris/registry_deploy.py
@@ -221,7 +221,7 @@ def delete_registry_ingress(owner=None, namespace="nuvolaris"):
         res += kube.kubectl("delete", "ingress",endpoint.api_ingress_name(namespace,"registry"))    
 
         if(ingress_class == 'traefik'):            
-            res = kube.kubectl("delete", "middleware.traefik.containo.us",endpoint.api_middleware_ingress_name(namespace,"registry"))         
+            res = kube.kubectl("delete", "middleware.traefik.io",endpoint.api_middleware_ingress_name(namespace,"registry"))
 
         return res
     except Exception as e:

--- a/nuvolaris/seaweedfs_ingress.py
+++ b/nuvolaris/seaweedfs_ingress.py
@@ -151,7 +151,7 @@ def delete_seaweedfs_ingress(runtime, namespace, ingress_class, type, owner=None
         res += kube.kubectl("delete", "ingress",endpoint.api_ingress_name(namespace,type))    
 
         if(ingress_class == 'traefik'):            
-            res = kube.kubectl("delete", "middleware.traefik.containo.us",endpoint.api_middleware_ingress_name(namespace,type))         
+            res = kube.kubectl("delete", "middleware.traefik.io",endpoint.api_middleware_ingress_name(namespace,type))
 
         return res
     except Exception as e:

--- a/nuvolaris/storage_static.py
+++ b/nuvolaris/storage_static.py
@@ -177,7 +177,7 @@ def delete_ow_static_endpoint(ucfg):
 
         if(ingress_class == 'traefik'):            
             middleware_name = static_middleware_ingress_name(namespace)
-            res += kube.kubectl("delete", "middleware.traefik.containo.us",middleware_name)            
+            res += kube.kubectl("delete", "middleware.traefik.io",middleware_name)
 
         ingress_name = static_ingress_name(namespace)
         res += kube.kubectl("delete", "ingress",ingress_name)
@@ -221,11 +221,11 @@ def delete_nuv_ingresses():
 
         if(ingress_class == 'traefik'):            
             middleware_name = static_middleware_ingress_name("nuvolaris")
-            res += kube.kubectl("delete", "middleware.traefik.containo.us",middleware_name)
+            res += kube.kubectl("delete", "middleware.traefik.io",middleware_name)
             
             if should_delete_www:
                 middleware_name = static_middleware_ingress_name("www-nuvolaris")
-                res += kube.kubectl("delete", "middleware.traefik.containo.us",middleware_name)             
+                res += kube.kubectl("delete", "middleware.traefik.io",middleware_name)
 
         ingress_name = static_ingress_name("nuvolaris")
         res += kube.kubectl("delete", "ingress",ingress_name)

--- a/nuvolaris/templates/traefik-middleware-tpl.yaml
+++ b/nuvolaris/templates/traefik-middleware-tpl.yaml
@@ -16,7 +16,7 @@
 # under the License.
 #
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   namespace: {{namespace}}


### PR DESCRIPTION
## Summary
- update Traefik middleware API references from `traefik.containo.us` to `traefik.io`
- align RBAC, templates and delete paths with the non-deprecated API version

## Source
- ported from luigidematteis/openserverless-operator commit `ea009004bb4124690df709e05271bd627bb370ce`
