### PR TITLE
fix: add secrets and pods RBAC rules for admin-api builder

### DIFF
--- a/deploy/nuvolaris-permissions/nuvolaris-wsku-roles.yaml
+++ b/deploy/nuvolaris-permissions/nuvolaris-wsku-roles.yaml
@@ -37,6 +37,14 @@ rules:
 - apiGroups: ["batch"]
   resources: ["jobs"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# assign the possibility to operate on secrets (admin api builder)
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+# assign the possibility to monitor build pods (admin api builder)
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list", "watch"]
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
## Summary

The deployer (admin-api builder) requires RBAC access to `secrets` and `pods` resources that are missing from the current `nuvolaris-wsku-role` definition.

## Added rules

**Secrets** (full CRUD):
- `build_service.py`: `create_registry_secret()` for docker registry auth, `get_secret()` to read registry credentials, `delete_secret()` to clean up after build

**Pods and pods/log** (read-only):
- `kube_api_client.py`: `get_pod_by_job_name()` to find the buildkit job pod, `stream_pod_logs()` to monitor build progress, `get_pod()` to check pod status

## Test plan

- [x] Tested on k3s cluster (lorenzo1.hz.nuvolaris.dev)
- [x] Without these permissions the builder fails with RBAC errors
- [x] With these permissions: full deployer pipeline works (build, push, deploy)
- [x] Cotemar pipeline (6 stages, custom runtime) deployed successfully
- [x] Running in production for 3 weeks

Related: nuvolaris/projects#409