### PR TITLE
Fix: patcher.py registry block passes wrong key to registry.patch

### DIFF
--- a/nuvolaris/patcher.py
+++ b/nuvolaris/patcher.py
@@ -162,7 +162,7 @@ def patch(diff, status, owner=None, name=None):
         components_updated = True 
 
     if "registry" in what_to_do:
-        registry.patch(status,what_to_do['milvus'], owner)
+        registry.patch(status,what_to_do['registry'], owner)
         components_updated = True                                      
 
     # handle update action on openwhisk


### PR DESCRIPTION
## Summary

In `nuvolaris/patcher.py`, the block guarded by `if "registry" in what_to_do` was incorrectly passing `what_to_do['milvus']` to `registry.patch()` instead of `what_to_do['registry']`.

## Root Cause

This is a copy-paste error from the adjacent `milvus` block. The guard condition correctly checks for `"registry"`, but the dictionary access used the wrong key.

## Impact

A `KeyError: 'milvus'` is raised in `whisk_update` whenever:
1. The diff contains `spec.components.registry` (registry is added or changed)
2. The diff does NOT contain `spec.components.milvus` (milvus is absent from `last-handled-configuration` or unchanged)

This silently breaks any platform update that touches the registry component without simultaneously touching milvus.

## Fix

One-line change: replace `what_to_do['milvus']` with `what_to_do['registry']` in the registry block.

## Testing

Verified by code inspection that all other `what_to_do` accesses in `patcher.py` correctly match their guard conditions. This block was the only mismatch.