### PR TITLE
build: unify build-and-load task with kube type detection

### DIFF
--- a/TaskfileBuild.yml
+++ b/TaskfileBuild.yml
@@ -47,16 +47,28 @@ tasks:
     - docker push ${MY_OPERATOR_IMAGE:-{{.OPERATOR_IMAGE}}}:{{.OPERATOR_TAG}}
 
   build-and-load:
-    - task: build
-    - > 
-      kind load docker-image 
-      ${MY_OPERATOR_IMAGE:-{{.OPERATOR_IMAGE}}}:{{.OPERATOR_TAG}} 
-      --name=nuvolaris
-
-  k3s:build-and-load:
-    - task: build
-    - >
-      docker save ${MY_OPERATOR_IMAGE:-{{.OPERATOR_IMAGE}}}:{{.OPERATOR_TAG}} | sudo k3s ctr images import -
+    silent: true
+    desc: Build the image and loads it to the local Kind, k3s, microk8s cluster
+    vars:
+      KUB_TYPE:
+        sh: "ops debug kube detect"
+    cmds:
+      - task: build
+      - |
+        IMG="${MY_OPERATOR_IMAGE:-{{.OPERATOR_IMAGE}}}:{{.OPERATOR_TAG}}"
+        if [ "{{.KUB_TYPE}}" = "kind" ]; then
+          echo "Loading image to kind"
+          kind load docker-image $IMG --name=nuvolaris
+        elif [ "{{.KUB_TYPE}}" = "k3s" ]; then
+          echo "Loading image to k3s"
+          docker save $IMG | sudo k3s ctr images import -
+        elif [ "{{.KUB_TYPE}}" = "microk8s" ]; then
+          echo "Loading image to microk8s"
+          docker save $IMG | microk8s ctr images import -
+        else
+          echo "Error: unsupported KUB_TYPE '{{.KUB_TYPE}}' for loading images"
+          exit 1
+        fi
 
   buildx-and-push:
     - > 

--- a/clusters/microk8s.yml
+++ b/clusters/microk8s.yml
@@ -32,7 +32,7 @@ vars:
         else echo unknown
         fi
   STACK: "{{.GITHUB_USER}}-nuvolaris-dev"
-  KUBECONFIG: "microk8s-{{.GITHUB_USER}}.kubeconfig"
+  MIK_KUBECONFIG: "microk8s-{{.GITHUB_USER}}.kubeconfig"
   
 tasks:
 
@@ -73,8 +73,8 @@ tasks:
         ssh -i id_rsa -o "StrictHostKeyChecking=no" \
         "ubuntu@$(cat {{.APIHOST}})" sudo cloud-init status --wait
         scp -i id_rsa -o "StrictHostKeyChecking=no" \
-        "ubuntu@$(cat {{.APIHOST}}):/etc/kubeconfig" {{.KUBECONFIG}}
-      - cp -v {{.KUBECONFIG}} ~/.kube/config
+        "ubuntu@$(cat {{.APIHOST}}):/etc/kubeconfig" {{.MIK_KUBECONFIG}}
+      - cp -v {{.MIK_KUBECONFIG}} ~/.kube/config
       - kubectl get nodes
 
   import-key: 
@@ -90,6 +90,6 @@ tasks:
     cmds:
     - echo user  {{.GITHUB_USER}}
     - echo stack {{.STACK}}
-    - echo kubeconfig {{.KUBECONFIG}}
+    - echo kubeconfig {{.MIK_KUBECONFIG}}
     silent: true
     


### PR DESCRIPTION
Merge the kind/k3s build-and-load tasks into a single task that detects the cluster type via `ops debug kube detect` and adds microk8s support. Rename microk8s.yml's KUBECONFIG var to MIK_KUBECONFIG to avoid clashing with the KUBECONFIG env var.