### PR TITLE
chore: changed detect from ops to ./detect.sh script

### DIFF
--- a/TaskfileBuild.yml
+++ b/TaskfileBuild.yml
@@ -51,7 +51,7 @@ tasks:
     desc: Build the image and loads it to the local Kind, k3s, microk8s cluster
     vars:
       KUB_TYPE:
-        sh: "ops debug kube detect"
+        sh: ./detect.sh
     cmds:
       - task: build
       - |


### PR DESCRIPTION
removed ops command from kube detection to avoid ops cli depenency in github actions